### PR TITLE
Remove Java dependency

### DIFF
--- a/.idea/modules/vyper-plugin.iml
+++ b/.idea/modules/vyper-plugin.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="vyper-plugin" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.vyperlang.plugin" external.system.module.version="0.2.0-alpha.1" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="vyper-plugin" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.vyperlang.plugin" external.system.module.version="0.2.0-alpha.2" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../..">

--- a/.idea/modules/vyper-plugin.main.iml
+++ b/.idea/modules/vyper-plugin.main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="vyper-plugin:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.vyperlang.plugin" external.system.module.type="sourceSet" external.system.module.version="0.2.0-alpha.1" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="vyper-plugin:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.vyperlang.plugin" external.system.module.type="sourceSet" external.system.module.version="0.2.0-alpha.2" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet external-system-id="GRADLE" type="kotlin-language" name="Kotlin">
       <configuration version="5" platform="JVM 17" allPlatforms="JVM [17]" useProjectSettings="false">
@@ -49,71 +49,40 @@
     <orderEntry type="library" name="Gradle: com.google.code.gson:gson:2.11.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Gradle: org.jetbrains:annotations:24.0.1" level="project" />
     <orderEntry type="module-library" scope="PROVIDED">
-      <library name="Gradle: unzipped.com.jetbrains.plugins:java:unzipped.com.jetbrains.plugins:ideaIC-IC-241.17011.79-withSources">
+      <library name="Gradle: com.jetbrains:ideaIC:2024.1.4">
         <CLASSES>
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/aether-dependency-resolver.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/debugger-memory-agent.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/java-frontback.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/java-impl.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/javac2.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jb-jdi.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jetbrains.kotlinx.metadata.jvm.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jgoodies-common.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jps-builders.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jps-builders-6.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jps-javac-extension.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jps-launcher.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jshell-frontend.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jshell-protocol.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/maven-resolver-connector-basic.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/maven-resolver-transport-file.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/maven-resolver-transport-http.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/sa-jdwp.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/app.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/app-client.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/bouncy-castle.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/external-system-rt.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/externalProcess-rt.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/forms_rt.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/groovy.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/grpc.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/idea_rt.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/intellij-coverage-agent-1.0.744.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/intellij-test-discovery.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/jps-model.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/jsch-agent.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/junit4.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/lib.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/lib-client.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/modules.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/opentelemetry.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/platform-loader.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/product.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/protobuf.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/rd.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/stats.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/testFramework.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/trove.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/util.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/util-8.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/util_rt.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/18591d4305f655dd54751b7d2bb8eec7e4005840/ideaIC-241.17011.79-sources.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" scope="PROVIDED">
-      <library name="Gradle: com.jetbrains:ideaIC:241.17011.79">
-        <ANNOTATIONS>
-          <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/241.18034.62/ideaIU-241.18034.62-annotations.zip!/" />
-        </ANNOTATIONS>
-        <CLASSES>
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/app.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/app-client.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/bouncy-castle.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/external-system-rt.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/externalProcess-rt.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/forms_rt.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/groovy.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/grpc.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/idea_rt.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/intellij-coverage-agent-1.0.744.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/intellij-test-discovery.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/jps-model.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/jsch-agent.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/junit4.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/lib.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/lib-client.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/modules.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/opentelemetry.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/platform-loader.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/product.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/protobuf.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/rd.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/stats.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/testFramework.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/trove.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/util.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/util-8.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/util_rt.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/18591d4305f655dd54751b7d2bb8eec7e4005840/ideaIC-241.17011.79-sources.jar!/" />
+          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2024.1.4/10c9315a376493de4f71bd4f3f435655ef350d87/ideaIC-2024.1.4-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/.idea/modules/vyper-plugin.test.iml
+++ b/.idea/modules/vyper-plugin.test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="vyper-plugin:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.vyperlang.plugin" external.system.module.type="sourceSet" external.system.module.version="0.2.0-alpha.1" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="vyper-plugin:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.vyperlang.plugin" external.system.module.type="sourceSet" external.system.module.version="0.2.0-alpha.2" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet external-system-id="GRADLE" type="kotlin-language" name="Kotlin">
       <configuration version="5" platform="JVM 17" allPlatforms="JVM [17]" useProjectSettings="false">
@@ -50,71 +50,40 @@
     <orderEntry type="library" name="Gradle: junit:junit:4.13.2" level="project" />
     <orderEntry type="library" name="Gradle: org.jetbrains:annotations:24.0.1" level="project" />
     <orderEntry type="module-library">
-      <library name="Gradle: unzipped.com.jetbrains.plugins:java:unzipped.com.jetbrains.plugins:ideaIC-IC-241.17011.79-withSources">
+      <library name="Gradle: com.jetbrains:ideaIC:2024.1.4">
         <CLASSES>
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/aether-dependency-resolver.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/debugger-memory-agent.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/java-frontback.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/java-impl.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/javac2.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jb-jdi.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jetbrains.kotlinx.metadata.jvm.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jgoodies-common.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jps-builders.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jps-builders-6.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jps-javac-extension.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jps-launcher.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jshell-frontend.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/jshell-protocol.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/maven-resolver-connector-basic.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/maven-resolver-transport-file.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/maven-resolver-transport-http.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/plugins/java/lib/sa-jdwp.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/app.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/app-client.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/bouncy-castle.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/external-system-rt.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/externalProcess-rt.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/forms_rt.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/groovy.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/grpc.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/idea_rt.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/intellij-coverage-agent-1.0.744.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/intellij-test-discovery.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/jps-model.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/jsch-agent.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/junit4.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/lib.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/lib-client.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/modules.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/opentelemetry.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/platform-loader.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/product.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/protobuf.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/rd.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/stats.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/testFramework.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/trove.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/util.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/util-8.jar!/" />
+          <root url="jar://$APPLICATION_HOME_DIR$/lib/util_rt.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/18591d4305f655dd54751b7d2bb8eec7e4005840/ideaIC-241.17011.79-sources.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library name="Gradle: com.jetbrains:ideaIC:241.17011.79">
-        <ANNOTATIONS>
-          <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/241.18034.62/ideaIU-241.18034.62-annotations.zip!/" />
-        </ANNOTATIONS>
-        <CLASSES>
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/app.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/app-client.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/bouncy-castle.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/external-system-rt.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/externalProcess-rt.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/forms_rt.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/groovy.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/grpc.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/idea_rt.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/intellij-coverage-agent-1.0.744.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/intellij-test-discovery.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/jps-model.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/jsch-agent.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/junit4.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/lib.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/lib-client.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/modules.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/opentelemetry.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/platform-loader.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/product.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/protobuf.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/rd.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/stats.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/testFramework.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/trove.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/util.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/util-8.jar!/" />
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/e09f76f10d23a686921c681f7df35f5607d507a0/ideaIC-241.17011.79/lib/util_rt.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/241.17011.79/18591d4305f655dd54751b7d2bb8eec7e4005840/ideaIC-241.17011.79-sources.jar!/" />
+          <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2024.1.4/10c9315a376493de4f71bd4f3f435655ef350d87/ideaIC-2024.1.4-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Changed
+- Add support for PyCharm ([#22](https://github.com/NikitaMishin/vyper-plugin/pull/22))
+- Update platform to version [`2024.1.4`](https://blog.jetbrains.com/idea/2024/06/intellij-idea-2024-1-4/)
+
 ## [0.2.0-alpha.1] - 2024-06-24
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,8 @@ group 'org.vyperlang.plugin'
 version property("pluginVersion").get()
 
 intellij {
-    // https://mvnrepository.com/artifact/com.jetbrains.intellij.java/java-plugin
-    plugins = ['com.intellij.java']
-    version = "241.17011.79"
+    plugins = []
+    version = "2024.1.4"
 }
 
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 kotlin_version=2.0.0
 kotlin.stdlib.default.dependency = false
-pluginVersion=0.2.0-alpha.1
+pluginVersion=0.2.0-alpha.2

--- a/src/main/kotlin/com/vyperplugin/editorActions/EnterProcessorAcrtion.kt
+++ b/src/main/kotlin/com/vyperplugin/editorActions/EnterProcessorAcrtion.kt
@@ -1,6 +1,0 @@
-package org.vyperlang.plugin.editorActions
-
-import com.intellij.openapi.compiler.CompilationStatusListener
-
-
-class Listener : CompilationStatusListener

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,8 +20,6 @@
     <change-notes>Troubleshooting compatibility issues.</change-notes>
 
     <depends>com.intellij.modules.lang</depends>
-    <depends>com.intellij.java</depends>
-
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- Add your extensions here -->


### PR DESCRIPTION
Fixes #22

- Add support for PyCharm by removing Java dependency
- Update platform to version [`2024.1.4`](https://blog.jetbrains.com/idea/2024/06/intellij-idea-2024-1-4/)